### PR TITLE
src/fw/coreboot.c: fix CBFS pointer calculation

### DIFF
--- a/src/fw/coreboot.c
+++ b/src/fw/coreboot.c
@@ -461,9 +461,10 @@ coreboot_cbfs_init(void)
         dprintf(1, "Invalid CBFS pointer %p\n", hdr);
         return;
     }
-    if (CONFIG_CBFS_LOCATION && (u32)hdr > CONFIG_CBFS_LOCATION)
-        // Looks like the pointer is relative to CONFIG_CBFS_LOCATION
-        hdr = (void*)hdr + CONFIG_CBFS_LOCATION;
+
+    // The pointer is relative to CONFIG_CBFS_LOCATION
+    hdr = (void*)hdr + CONFIG_CBFS_LOCATION;
+
     if (hdr->magic != cpu_to_be32(CBFS_HEADER_MAGIC)) {
         dprintf(1, "Unable to find CBFS (ptr=%p; got %x not %x)\n"
                 , hdr, hdr->magic, cpu_to_be32(CBFS_HEADER_MAGIC));


### PR DESCRIPTION
A 32b offset to the CBFS header is located at the end of CBFS. This is not
an absolute pointer. It works as expected when CBFS ends at 4GB, but doesn't
work in other cases (Gemini Lake, Apollo Lake).

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>